### PR TITLE
Bugfix for event links

### DIFF
--- a/src/main/java/de/arnefeil/bewegungsmelder/adapter/EventAdapter.java
+++ b/src/main/java/de/arnefeil/bewegungsmelder/adapter/EventAdapter.java
@@ -95,6 +95,7 @@ public class EventAdapter extends ArrayAdapter<Event> {
                     }
                     bandTitle.setText(Html.fromHtml(bandDescription));
                     bandTitle.setPadding(0, 0, 0, 5);
+                    bandTitle.setMovementMethod(LinkMovementMethod.getInstance());
                     viewHolder.tvBands.addView(bandTitle);
                 }
             }


### PR DESCRIPTION
Hey Arne,

I've always wondered why it is not possible to open band links in your great Bewegungsmelder app. It turned out that the views containing band links don't have a proper [MovementMethod](http://developer.android.com/reference/android/text/method/MovementMethod.html) set.

I've fixed this and refactored the whole EventAdapter to use a [view holder](http://developer.android.com/training/improving-layouts/smooth-scrolling.html).
