### PR TITLE
Fix build on fdroid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,6 @@ buildscript {
 }
 apply plugin: 'com.android.application'
 
-repositories {
-    mavenCentral()
-}
-
 android {
     signingConfigs {
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
     repositories {
         mavenCentral()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Hi Arne,

I got a mail that the build is failing on the fdroid build system. It seems that gradle 3.0.0 is not in the mavenCentral() repo but in the google() repo - I added it now.

Here the full mail for reference:

> 
> 
> michel@debian:~/git/fdroiddata$ fdroid build -vl de.arnefeil.bewegungsmelder
> Clonage dans 'build/de.arnefeil.bewegungsmelder'...
> INFO: Building version 2.0.3 (140632) of de.arnefeil.bewegungsmelder
> INFO: Getting source for revision 5c1ace248217bb5902509536d8d9b26dbd009295
> INFO: Creating local.properties file at build/de.arnefeil.bewegungsmelder/local.properties
> INFO: Cleaned build.gradle of keysigning configs at build/de.arnefeil.bewegungsmelder/build.gradle
> INFO: Cleaning Gradle project...
> Starting a Gradle Daemon (subsequent builds will be faster)
> 
> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> A problem occurred configuring root project 'de.arnefeil.bewegungsmelder'.
>> Could not resolve all files for configuration ':classpath'.
>    > Could not find com.android.tools.build:gradle:3.0.0.
>      Searched in the following locations:
>          https://repo1.maven.org/maven2/com/android/tools/build/gradle/3.0.0/gradle-3.0.0.pom
>          https://repo1.maven.org/maven2/com/android/tools/build/gradle/3.0.0/gradle-3.0.0.jar
>      Required by:
>          project :
> 
> * Try:
> Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
> 
> * Get more help at https://help.gradle.org
> 
> BUILD FAILED in 15s
> ERROR: Could not build app de.arnefeil.bewegungsmelder: Error cleaning de.arnefeil.bewegungsmelder:2.0.3
> ==== detail begin ====
> Starting a Gradle Daemon (subsequent builds will be faster)
> 
> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> A problem occurred configuring root project 'de.arnefeil.bewegungsmelder'.
>> Could not resolve all files for configuration ':classpath'.
>    > Could not find com.android.tools.build:gradle:3.0.0.
>      Searched in the following locations:
>          https://repo1.maven.org/maven2/com/android/tools/build/gradle/3.0.0/gradle-3.0.0.pom
>          https://repo1.maven.org/maven2/com/android/tools/build/gradle/3.0.0/gradle-3.0.0.jar
>      Required by:
>          project :
> 
> * Try:
> Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
> 
> * Get more help at https://help.gradle.org
> 
> BUILD FAILED in 15s
> ==== detail end ====
> INFO: Finished.
> INFO: 1 builds failed
> 
> I think you need to add the google() repo in https://github.com/arnef/bewegungsmelder-android/blob/master/build.gradle
> 
> Could you please tag releases for the bot to automatically update metadata files?
> 

They also ask you to tag releases so they can automatically build new versions. Would you do that?

Best,
Philip
