### PR TITLE
Use jcenter() instead of mavenCentral()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcentral()
+        jcenter()
         google()
     }
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcentral()
         google()
     }
     dependencies {


### PR DESCRIPTION
Hi @arnef,

to fix the build on fdroid we also need this change. It seems that mavenCentral() doesn't include org.jetbrains.trove4j which is a dependency of gradle:3.0.0.

See https://gitlab.com/fdroid/fdroiddata/merge_requests/2608 for the full log.

Best,
Philip